### PR TITLE
Improved Bucket Drain Mechanics

### DIFF
--- a/src/main/java/mega/fluidlogged/internal/bucket/FLBucketDriver.java
+++ b/src/main/java/mega/fluidlogged/internal/bucket/FLBucketDriver.java
@@ -31,12 +31,8 @@ import mega.fluidlogged.api.FLBlockAccess;
 import mega.fluidlogged.internal.world.FLWorldDriver;
 
 import net.minecraft.block.Block;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
 import net.minecraftforge.fluids.Fluid;

--- a/src/main/java/mega/fluidlogged/internal/bucket/FLBucketDriver.java
+++ b/src/main/java/mega/fluidlogged/internal/bucket/FLBucketDriver.java
@@ -72,30 +72,6 @@ public class FLBucketDriver {
         }
     }
 
-    protected MovingObjectPosition getMovingObjectPositionFromPlayer(World worldIn, EntityPlayer player, boolean useLiquids)
-    {
-        float f = 1.0F;
-        float f1 = player.prevRotationPitch + (player.rotationPitch - player.prevRotationPitch) * f;
-        float f2 = player.prevRotationYaw + (player.rotationYaw - player.prevRotationYaw) * f;
-        double d0 = player.prevPosX + (player.posX - player.prevPosX) * (double)f;
-        double d1 = player.prevPosY + (player.posY - player.prevPosY) * (double)f + (double)(worldIn.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight() : player.getEyeHeight()); // isRemote check to revert changes to ray trace position due to adding the eye height clientside and player yOffset differences
-        double d2 = player.prevPosZ + (player.posZ - player.prevPosZ) * (double)f;
-        Vec3 vec3 = Vec3.createVectorHelper(d0, d1, d2);
-        float f3 = MathHelper.cos(-f2 * 0.017453292F - (float)Math.PI);
-        float f4 = MathHelper.sin(-f2 * 0.017453292F - (float)Math.PI);
-        float f5 = -MathHelper.cos(-f1 * 0.017453292F);
-        float f6 = MathHelper.sin(-f1 * 0.017453292F);
-        float f7 = f4 * f5;
-        float f8 = f3 * f5;
-        double d3 = 5.0D;
-        if (player instanceof EntityPlayerMP)
-        {
-            d3 = ((EntityPlayerMP)player).theItemInWorldManager.getBlockReachDistance();
-        }
-        Vec3 vec31 = vec3.addVector((double)f7 * d3, (double)f6 * d3, (double)f8 * d3);
-        return worldIn.func_147447_a(vec3, vec31, useLiquids, !useLiquids, false);
-    }
-
     @SubscribeEvent(
             priority = EventPriority.HIGHEST
     )


### PR DESCRIPTION
This re-works the bucket drain mechanics to match vanilla MC a little closer. Presently in FluidLogged if for example you try to empty a bucket and hit a stone block underneath a fence post, you can't empty the bucket. Whereas in normal fluid placing, hitting the block would place the fluid in the block above it(or to the side, etc).

This modifies the FluidLogged bucket draining mechanics to more accurately perform these checks, such that if for example you empty a bucket on solid block next to a fluidloggable block, then it will allow you to empty it and perform the fluidlogging.

There seems to still be a few issues with the bucket fill mechanics, but I haven't properly sorted that yet, so I will probably improve those similarly in another PR.